### PR TITLE
Bump version to 2.1.1 in installer and package; update project references

### DIFF
--- a/Installer/Assets/PlayerPrefsEx Installer/Installer.cs
+++ b/Installer/Assets/PlayerPrefsEx Installer/Installer.cs
@@ -16,7 +16,7 @@ namespace Extensions.Unity.PlayerPrefsEx.Installer
     public static partial class Installer
     {
         public const string PackageId = "extensions.unity.playerprefsex";
-        public const string Version = "2.1.0";
+        public const string Version = "2.1.1";
 
         static Installer()
         {

--- a/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
@@ -3,8 +3,7 @@
     "rootNamespace": "Extensions.Unity.PlayerPrefsEx.Tests",
     "references": [
         "UnityEngine.TestRunner",
-        "Extensions.Unity.PlayerPrefsEx",
-        "UnityEditor.TestRunner"
+        "Extensions.Unity.PlayerPrefsEx"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -5,7 +5,7 @@
     "name": "Ivan Murzak",
     "url": "https://github.com/IvanMurzak"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "unity": "2018.3",
   "description": "Lightweight package with optimized advanced version of PlayerPrefs. Under the hood it uses the same PlayerPrefs system, but creates flexible wrapper for default system.",
   "keywords": [

--- a/Unity-Package/Unity-Package.slnx
+++ b/Unity-Package/Unity-Package.slnx
@@ -1,6 +1,6 @@
 ﻿<Solution>
+  <Project Path="Extensions.Unity.PlayerPrefsEx.Tests.csproj" />
   <Project Path="Extensions.Unity.PlayerPrefsEx.csproj" />
   <Project Path="Extensions.Unity.PlayerPrefsEx.Sample.csproj" />
-  <Project Path="Extensions.Unity.PlayerPrefsEx.Tests.csproj" />
   <Project Path="Extensions.Unity.PlayerPrefsEx.Editor.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
This pull request contains a minor version bump for the PlayerPrefsEx package, along with some small adjustments to project configuration and test references.

- Version update:
  * Updated the package version from `2.1.0` to `2.1.1` in both `Installer.cs` and `package.json` to reflect the new release. [[1]](diffhunk://#diff-a2f02f057f8c8c6e060e7eda490f41bd747e14aa46955a82607f71d806ebffdcL19-R19) [[2]](diffhunk://#diff-8da1c9d7c85f15d189f990e4770b9567f3af4e9c7cac1f102e2176066216a5f2L8-R8)

- Project and test configuration:
  * Removed the `UnityEditor.TestRunner` reference from the `Extensions.Unity.PlayerPrefsEx.Tests.asmdef` file, likely to streamline test dependencies.
  * Reordered the inclusion of `Extensions.Unity.PlayerPrefsEx.Tests.csproj` in the `Unity-Package.slnx` solution file, moving it above the sample project.