### PR TITLE
fix(unit-tests): make tests opt-in via testables

### DIFF
--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -94,7 +94,7 @@ This package includes tests but does not load them in the Unity Test Runner by d
 }
 ```
 
-See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Adding tests to a package](https://docs.unity3d.com/Manual/cus-tests.html).
+See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Add tests to your package](https://docs.unity3d.com/Manual/cus-tests.html).
 
 # Features
 

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -79,6 +79,21 @@ When you package is distributed, you can install it into any Unity project.
 openupm add extensions.unity.playerprefsex
 ```
 
+## Running the package tests (opt-in)
+
+This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package to the `testables` array in your project manifest (`Packages/manifest.json`):
+
+```json
+{
+  "dependencies": {
+      "extensions.unity.playerprefsex": "X.X.X"
+   },
+  "testables": ["extensions.unity.playerprefsex"]
+}
+```
+
+See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Adding tests to a package](https://docs.unity3d.com/Manual/cus-tests.html).
+
 # Features
 
  ✔️ Key is encrypted. Encrypted depends on a device. Much more harder for hackers to hack your data. Saved data at one device won't work on another one if someone copied it from device to device. In the same time for UnityEditor the device identifier is a constant. That means data copied between devices could be opened if you work on multiple machines and want to save/sent/load saved data on different machines.

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -81,14 +81,16 @@ openupm add extensions.unity.playerprefsex
 
 ## Running the package tests (opt-in)
 
-This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package to the `testables` array in your project manifest (`Packages/manifest.json`):
+This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package name to the existing `testables` array in your project manifest (`Packages/manifest.json`). For example, your manifest might include:
 
 ```json
 {
   "dependencies": {
-      "extensions.unity.playerprefsex": "X.X.X"
-   },
-  "testables": ["extensions.unity.playerprefsex"]
+    "extensions.unity.playerprefsex": "X.X.X"
+  },
+  "testables": [
+    "extensions.unity.playerprefsex"
+  ]
 }
 ```
 

--- a/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
@@ -13,7 +13,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
@@ -2,14 +2,13 @@
     "name": "Extensions.Unity.PlayerPrefsEx.Editor.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEditor.TestRunner",
-        "UnityEngine.TestRunner",
         "Extensions.Unity.PlayerPrefsEx"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],

--- a/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
@@ -2,16 +2,14 @@
     "name": "Extensions.Unity.PlayerPrefsEx.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
         "Extensions.Unity.PlayerPrefsEx"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "overrideReferences": false,
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -5,7 +5,7 @@
     "name": "Ivan Murzak",
     "url": "https://github.com/IvanMurzak"
   },
-  "version": "2.1.2",
+  "version": "2.1.3",
   "unity": "2018.3",
   "description": "Lightweight package with optimized advanced version of PlayerPrefs. Under the hood it uses the same PlayerPrefs system, but creates flexible wrapper for default system.",
   "keywords": [

--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -34,6 +34,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -37,6 +37,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -38,6 +38,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",


### PR DESCRIPTION

## Summary

- Add `"testables": ["extensions.unity.playerprefsex"]` to Unity-Tests project manifests (2022.3, 2023.2, 6000.3) so package tests load only in those projects; other dependents do not load package tests by default.
- Document in package README that tests are opt-in and that consumers must add the package to the `testables` array in `Packages/manifest.json` to run the package tests.
- Existing test asmdefs (`optionalUnityReferences: TestAssemblies`) support testables; no asmdef changes required for testables.

## Documentation

- [Unity: Add tests to your package](https://docs.unity3d.com/Manual/cus-tests.html)
- [Unity: testables (project manifest)](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables)
