### PR TITLE
Make tests opt-in via testables and update documentation

### DIFF
--- a/Installer/Assets/PlayerPrefsEx Installer/Installer.cs
+++ b/Installer/Assets/PlayerPrefsEx Installer/Installer.cs
@@ -16,7 +16,7 @@ namespace Extensions.Unity.PlayerPrefsEx.Installer
     public static partial class Installer
     {
         public const string PackageId = "extensions.unity.playerprefsex";
-        public const string Version = "2.1.2";
+        public const string Version = "2.1.3";
 
         static Installer()
         {

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -94,7 +94,7 @@ This package includes tests but does not load them in the Unity Test Runner by d
 }
 ```
 
-See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Adding tests to a package](https://docs.unity3d.com/Manual/cus-tests.html).
+See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Add tests to your package](https://docs.unity3d.com/Manual/cus-tests.html).
 
 # Features
 

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -79,6 +79,21 @@ When you package is distributed, you can install it into any Unity project.
 openupm add extensions.unity.playerprefsex
 ```
 
+## Running the package tests (opt-in)
+
+This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package to the `testables` array in your project manifest (`Packages/manifest.json`):
+
+```json
+{
+  "dependencies": {
+      "extensions.unity.playerprefsex": "X.X.X"
+   },
+  "testables": ["extensions.unity.playerprefsex"]
+}
+```
+
+See [Unity's documentation on testables](https://docs.unity3d.com/Manual/upm-manifestPrj.html#testables) and [Adding tests to a package](https://docs.unity3d.com/Manual/cus-tests.html).
+
 # Features
 
  ✔️ Key is encrypted. Encrypted depends on a device. Much more harder for hackers to hack your data. Saved data at one device won't work on another one if someone copied it from device to device. In the same time for UnityEditor the device identifier is a constant. That means data copied between devices could be opened if you work on multiple machines and want to save/sent/load saved data on different machines.

--- a/Unity-Package/Assets/root/README.md
+++ b/Unity-Package/Assets/root/README.md
@@ -81,14 +81,16 @@ openupm add extensions.unity.playerprefsex
 
 ## Running the package tests (opt-in)
 
-This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package to the `testables` array in your project manifest (`Packages/manifest.json`):
+This package includes tests but does not load them in the Unity Test Runner by default. To run the package's tests in your project, add the package name to the existing `testables` array in your project manifest (`Packages/manifest.json`). For example, your manifest might include:
 
 ```json
 {
   "dependencies": {
-      "extensions.unity.playerprefsex": "X.X.X"
-   },
-  "testables": ["extensions.unity.playerprefsex"]
+    "extensions.unity.playerprefsex": "X.X.X"
+  },
+  "testables": [
+    "extensions.unity.playerprefsex"
+  ]
 }
 ```
 

--- a/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
@@ -13,7 +13,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef
@@ -2,14 +2,13 @@
     "name": "Extensions.Unity.PlayerPrefsEx.Editor.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEditor.TestRunner",
-        "UnityEngine.TestRunner",
         "Extensions.Unity.PlayerPrefsEx"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],

--- a/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/Extensions.Unity.PlayerPrefsEx.Tests.asmdef
@@ -2,16 +2,14 @@
     "name": "Extensions.Unity.PlayerPrefsEx.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
         "Extensions.Unity.PlayerPrefsEx"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "overrideReferences": false,
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -5,7 +5,7 @@
     "name": "Ivan Murzak",
     "url": "https://github.com/IvanMurzak"
   },
-  "version": "2.1.2",
+  "version": "2.1.3",
   "unity": "2018.3",
   "description": "Lightweight package with optimized advanced version of PlayerPrefs. Under the hood it uses the same PlayerPrefs system, but creates flexible wrapper for default system.",
   "keywords": [

--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -34,6 +34,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -37,6 +37,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -38,6 +38,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "testables": ["extensions.unity.playerprefsex"],
   "scopedRegistries": [
     {
       "name": "package.openupm.com",


### PR DESCRIPTION
This pull request updates the package version to 2.1.3 and improves the test configuration and documentation for the `extensions.unity.playerprefsex` Unity package. The main focus is to clarify how to enable and run package tests, ensure test assemblies are properly configured, and update project manifests to support test discovery.

**Testing and Documentation Improvements:**

* Added documentation to the `README.md` explaining how to enable and run the package's tests by adding the package to the `testables` array in `Packages/manifest.json`, with links to relevant Unity documentation.
* Updated test assembly definition files (`Extensions.Unity.PlayerPrefsEx.Editor.Tests.asmdef`, `Extensions.Unity.PlayerPrefsEx.Tests.asmdef`) to use `optionalUnityReferences` for `TestAssemblies`, set `UNITY_INCLUDE_TESTS` in `defineConstraints`, and simplify references to improve test discoverability and compatibility. [[1]](diffhunk://#diff-4e79d024ff9fe1050291130d7668a508a04f9539888cfc18b1245d55c4138481L5-R18) [[2]](diffhunk://#diff-2d65317c63d5057e12e534c9cadfede37fc24e765673f6fd2cdeb3a70aab7a3aL5-R12)
* Added the package to the `testables` array in example Unity project manifests to ensure the package tests are loaded by the Unity Test Runner. [[1]](diffhunk://#diff-548f872151ecb8cd2a6da55d353947e28d3503622a13642c725bbcfb087d9cfdR37) [[2]](diffhunk://#diff-0b3176147edc0a369b84399c3e0b7e81bc3704916d072979727c6c5556dbb719R40) [[3]](diffhunk://#diff-17e1786e389dfd96429cf6f09e8d2dc5b88829813b0eee2a0d03977c156c06adR41)

**Version Updates:**

* Bumped the package version from 2.1.2 to 2.1.3 in `package.json` and the `Installer` class to reflect these changes. [[1]](diffhunk://#diff-8da1c9d7c85f15d189f990e4770b9567f3af4e9c7cac1f102e2176066216a5f2L8-R8) [[2]](diffhunk://#diff-a2f02f057f8c8c6e060e7eda490f41bd747e14aa46955a82607f71d806ebffdcL19-R19)